### PR TITLE
fix rss xml escape chars bug

### DIFF
--- a/actions/rss.py
+++ b/actions/rss.py
@@ -1,5 +1,6 @@
 import copy
 from datetime import datetime, timedelta
+from xml.sax.saxutils import escape
 
 from jinja2 import Environment, PackageLoader
 
@@ -28,10 +29,13 @@ def generate(datas_):
                 deadline = deadline.strftime(STANDARD_TIME_FORMAT)
 
             content = '<h3>Description</h3>{}<h3>Deadline: {}</h3><h3>Reward: {}</h3>'.format(
-                description, deadline, reward)
+                escape(description), deadline, reward)
             c['start_time'] = start_time
             c['deadline'] = deadline
             c['content'] = content
+            c['name'] = escape(c['name'])
+            c['description'] = escape(c['description'])
+            c['url'] = escape(c['url'])
 
     update = datetime.utcnow() + timedelta(hours=8)
     update = update.strftime(STANDARD_TIME_FORMAT)


### PR DESCRIPTION
生成的rss.xml内容中若有"< & >"等特殊字符需要escape，否则会报错，如下图所示：  
![error on line 34 at column 61: EntityRef: expecting ';'](https://i.loli.net/2020/06/17/OISpsD1aXA7fbhC.png)    
  
pr中对description, name, url等用xml.sax.saxutils.escape做了处理。  